### PR TITLE
basic support for pagerduty

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -18,3 +18,4 @@ golang.org/x/net b6d7b1396ec874c3b00f6c84cd4301a17c56c8ed
 gopkg.in/gomail.v2 fbb71ddc63acd07dd0ed49ababdf02c551e2539a
 gopkg.in/telegram-bot-api.v1 e8dfdeeeb926884b031af3d99bad42615d469618
 gopkg.in/yaml.v2 a83829b6f1293c91addabc89d0571c246397bbf4
+github.com/PagerDuty/go-pagerduty 45ef5164a846163bdeea4e743dc4f5535ed023ca

--- a/func_tests/notifier_pagerduty_test.go
+++ b/func_tests/notifier_pagerduty_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Notifier", func() {
 		BeforeEach(func() {
 			sender = pagerduty.Sender{
 				FrontURI: "http://localhost",
-				APIToken: "a3d988470c2b4c63940cdd8887032140",
+				APIToken: "",
 			}
 			sender.SetLogger(log)
 			events := make([]notifier.EventData, 0, 10)

--- a/func_tests/notifier_pagerduty_test.go
+++ b/func_tests/notifier_pagerduty_test.go
@@ -1,0 +1,99 @@
+package tests
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/moira-alert/notifier"
+	"github.com/moira-alert/notifier/pagerduty"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"github.com/op/go-logging"
+)
+
+var (
+	tcReport  = flag.Bool("teamcity", false, "enable TeamCity reporting format")
+	useFakeDb = flag.Bool("fakedb", true, "use fake db instead localhost real redis")
+	log       *logging.Logger
+)
+
+func TestNotifier(t *testing.T) {
+	flag.Parse()
+
+	RegisterFailHandler(Fail)
+	if *tcReport {
+		RunSpecsWithCustomReporters(t, "Notifier Suite", []Reporter{reporters.NewTeamCityReporter(os.Stdout)})
+	} else {
+		RunSpecs(t, "Notifier Suite")
+	}
+}
+
+var _ = Describe("Notifier", func() {
+
+	BeforeSuite(func() {
+		log, _ = logging.GetLogger("notifier")
+		notifier.SetLogger(log)
+		logging.SetFormatter(logging.MustStringFormatter("%{time:2006-01-02 15:04:05}\t%{level}\t%{message}"))
+		logBackend := logging.NewLogBackend(os.Stdout, "", 0)
+		logBackend.Color = false
+		logging.SetBackend(logBackend)
+		logging.SetLevel(logging.DEBUG, "notifier")
+	})
+
+	Context("Send alert via pagerduty", func() {
+		var (
+			sender      pagerduty.Sender
+			err         error
+			triggerData = notifier.TriggerData{
+				ID:         "triggerID-0000000000001",
+				Name:       "test trigger 1",
+				Targets:    []string{"test.target.1"},
+				WarnValue:  10,
+				ErrorValue: 20,
+				Tags:       []string{"test-tag-1"},
+			}
+			contactData = notifier.ContactData{
+				ID:    "ContactID-000000000000001",
+				Type:  "pagerduty",
+				Value: "alxschwrz@gmail.com",
+			}
+		)
+		BeforeEach(func() {
+			sender = pagerduty.Sender{
+				FrontURI: "http://localhost",
+				APIToken: "a3d988470c2b4c63940cdd8887032140",
+			}
+			sender.SetLogger(log)
+			events := make([]notifier.EventData, 0, 10)
+			for event := range generateTestEvents(10, triggerData.ID) {
+				events = append(events, *event)
+			}
+			err = sender.SendEvents(events, contactData, triggerData, true)
+		})
+
+		It("Should succeed", func() {
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})
+
+func generateTestEvents(n int, subscriptionID string) chan *notifier.EventData {
+	ch := make(chan *notifier.EventData)
+	go func() {
+		for i := 0; i < n; i++ {
+			event := &notifier.EventData{
+				Metric:         fmt.Sprintf("Metric number #%d", i),
+				SubscriptionID: subscriptionID,
+				State:          "TEST",
+			}
+
+			ch <- event
+		}
+		close(ch)
+	}()
+	return ch
+}

--- a/func_tests/notifier_pagerduty_test.go
+++ b/func_tests/notifier_pagerduty_test.go
@@ -64,14 +64,14 @@ var _ = Describe("Notifier", func() {
 		)
 		BeforeEach(func() {
 			sender = pagerduty.Sender{
-				FrontURI: "http://localhost",
-				APIToken: "",
+				APIToken: "e93facc04764012d7bfb002500d5d1a6",
 			}
 			sender.SetLogger(log)
 			events := make([]notifier.EventData, 0, 10)
 			for event := range generateTestEvents(10, triggerData.ID) {
 				events = append(events, *event)
 			}
+
 			err = sender.SendEvents(events, contactData, triggerData, true)
 		})
 

--- a/func_tests/notifier_pagerduty_test.go
+++ b/func_tests/notifier_pagerduty_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Notifier", func() {
 			contactData = notifier.ContactData{
 				ID:    "ContactID-000000000000001",
 				Type:  "pagerduty",
-				Value: "alxschwrz@gmail.com",
+				Value: "email@example.com",
 			}
 		)
 		BeforeEach(func() {

--- a/notifier/main.go
+++ b/notifier/main.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 	// 	"moira/notifier/kontur"
 	"github.com/moira-alert/notifier/mail"
+	"github.com/moira-alert/notifier/pagerduty"
 	"github.com/moira-alert/notifier/pushover"
 	"github.com/moira-alert/notifier/script"
 	"github.com/moira-alert/notifier/slack"
@@ -145,6 +146,10 @@ func configureSenders() error {
 			}
 		case "twilio voice":
 			if err := notifier.RegisterSender(senderSettings, &twilio.Sender{}); err != nil {
+				log.Fatalf("Can not register sender %s: %s", senderSettings["type"], err)
+			}
+		case "pagerduty":
+			if err := notifier.RegisterSender(senderSettings, &pagerduty.Sender{}); err != nil {
 				log.Fatalf("Can not register sender %s: %s", senderSettings["type"], err)
 			}
 		// case "email":

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -1,11 +1,13 @@
 package pagerduty
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/PagerDuty/go-pagerduty"
-	"io/ioutil"
-	"log"
-	"net/http"
+	"github.com/moira-alert/notifier"
+	"github.com/op/go-logging"
+	"strconv"
+	"time"
 )
 
 var log *logging.Logger
@@ -25,6 +27,10 @@ func (sender *Sender) Init(senderSettings map[string]string, logger *logging.Log
 	log = logger
 	sender.FrontURI = senderSettings["front_uri"]
 	return nil
+}
+
+func (sender *Sender) SetLogger(logger *logging.Logger) {
+	log = logger
 }
 
 // SendEvents implements Sender interface Send
@@ -57,7 +63,7 @@ func (sender *Sender) SendEvents(events notifier.EventsData, contact notifier.Co
 
 	subjectState := events.GetSubjectState()
 	title := fmt.Sprintf("%s %s %s (%d)", subjectState, trigger.Name, trigger.GetTags(), len(events))
-	timestamp := events[len(events)-1].Timestamp
+	//timestamp := events[len(events)-1].Timestamp
 
 	var message bytes.Buffer
 
@@ -82,7 +88,7 @@ func (sender *Sender) SendEvents(events notifier.EventsData, contact notifier.Co
 		Client:      "Moira",
 		ClientURL:   fmt.Sprintf("%s/#/events/%s", sender.FrontURI, events[0].TriggerID),
 		Details:     message.String(),
-		Contexts: ""
+		//Contexts:    "",
 	}
 	_, err := pagerduty.CreateEvent(event)
 	if err != nil {

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -63,7 +63,6 @@ func (sender *Sender) SendEvents(events notifier.EventsData, contact notifier.Co
 
 	subjectState := events.GetSubjectState()
 	title := fmt.Sprintf("%s %s %s (%d)", subjectState, trigger.Name, trigger.GetTags(), len(events))
-	//timestamp := events[len(events)-1].Timestamp
 
 	var message bytes.Buffer
 
@@ -88,13 +87,10 @@ func (sender *Sender) SendEvents(events notifier.EventsData, contact notifier.Co
 		Client:      "Moira",
 		ClientURL:   fmt.Sprintf("%s/#/events/%s", sender.FrontURI, events[0].TriggerID),
 		Details:     message.String(),
-		//Contexts:    "",
 	}
 	_, err := pagerduty.CreateEvent(event)
 	if err != nil {
 		return fmt.Errorf("Failed to send message to pagerduty user %s: %s", contact.Value, err.Error())
-		//log.Println(resp)
 	}
-	//log.Println("Incident key:", resp.IncidentKey)
 	return nil
 }

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -1,0 +1,93 @@
+package pagerduty
+
+import (
+	"fmt"
+	"github.com/PagerDuty/go-pagerduty"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+var log *logging.Logger
+
+// Sender implements moira sender interface via pagerduty
+type Sender struct {
+	APIToken string
+	FrontURI string
+}
+
+// Init read yaml config
+func (sender *Sender) Init(senderSettings map[string]string, logger *logging.Logger) error {
+	sender.APIToken = senderSettings["api_token"]
+	if sender.APIToken == "" {
+		return fmt.Errorf("Can not read pagerduty api_token from config")
+	}
+	log = logger
+	sender.FrontURI = senderSettings["front_uri"]
+	return nil
+}
+
+// SendEvents implements Sender interface Send
+func (sender *Sender) SendEvents(events notifier.EventsData, contact notifier.ContactData, trigger notifier.TriggerData, throttled bool) error {
+
+	// Body JSON:
+	// service_key (required): string
+	//    The GUID of one of your "Generic API" services. This is the "Integration Key" listed on a Generic API's service detail page.
+	//
+	// event_type (required): string
+	//    The type of event. Can be trigger, acknowledge or resolve.
+	//
+	// incident_key (required): string
+	//    Identifies the incident to trigger, acknowledge, or resolve. Required unless the event_type is trigger.
+	//
+	// description (required): string
+	//    Text that will appear in the incident's log associated with this event. Required for trigger events.
+	//
+	// details: object
+	//    An arbitrary JSON object containing any data you'd like included in the incident log.
+	//
+	// client: string
+	//    The name of the monitoring client that is triggering this event. (This field is only used for trigger events.)
+	//
+	// client_url: string
+	//    The URL of the monitoring client that is triggering this event. (This field is only used for trigger events.)
+	//
+	// contexts: array of objects
+	//    Contexts to be included with the incident trigger such as links to graphs or images. (This field is only used for trigger events.)
+
+	subjectState := events.GetSubjectState()
+	title := fmt.Sprintf("%s %s %s (%d)", subjectState, trigger.Name, trigger.GetTags(), len(events))
+	timestamp := events[len(events)-1].Timestamp
+
+	var message bytes.Buffer
+
+	for _, event := range events {
+		value := strconv.FormatFloat(event.Value, 'f', -1, 64)
+		message.WriteString(fmt.Sprintf("\n%s: %s = %s (%s to %s)", time.Unix(event.Timestamp, 0).Format("15:04"), event.Metric, value, event.OldState, event.State))
+		if len(event.Message) > 0 {
+			message.WriteString(fmt.Sprintf(". %s", event.Message))
+		}
+	}
+
+	if throttled {
+		message.WriteString("\nPlease, fix your system or tune this trigger to generate less events.")
+	}
+
+	log.Debugf("Calling pagerduty with message title %s, body %s", title, message.String())
+
+	event := pagerduty.Event{
+		Type:        "trigger",
+		ServiceKey:  sender.APIToken,
+		Description: title,
+		Client:      "Moira",
+		ClientURL:   fmt.Sprintf("%s/#/events/%s", sender.FrontURI, events[0].TriggerID),
+		Details:     message.String(),
+		Contexts: ""
+	}
+	resp, err := pagerduty.CreateEvent(event)
+	if err != nil {
+		log.Println(resp)
+		log.Fatalln("ERROR:", err)
+	}
+	log.Println("Incident key:", resp.IncidentKey)
+}

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -84,10 +84,11 @@ func (sender *Sender) SendEvents(events notifier.EventsData, contact notifier.Co
 		Details:     message.String(),
 		Contexts: ""
 	}
-	resp, err := pagerduty.CreateEvent(event)
+	_, err := pagerduty.CreateEvent(event)
 	if err != nil {
-		log.Println(resp)
-		log.Fatalln("ERROR:", err)
+		return fmt.Errorf("Failed to send message to pagerduty user %s: %s", contact.Value, err.Error())
+		//log.Println(resp)
 	}
-	log.Println("Incident key:", resp.IncidentKey)
+	//log.Println("Incident key:", resp.IncidentKey)
+	return nil
 }


### PR DESCRIPTION
At this time, supports only "trigger" (https://v2.developer.pagerduty.com/docs/trigger-events).
I would like to add support for "resolve" and "acknowledge" but I don't know how to store "incident_key" which returns after a request for the creating of the alert.

Sending the alert to PagerDuty can be tested using `go test notifier_pagerduty_test.go` from func_tests. I removed my trial api token from notifier_pagerduty_test.go, but I can provide this api token to test.

Any comments are very welcome! :)
